### PR TITLE
Add schema configuration dataclasses

### DIFF
--- a/schema_config/__init__.py
+++ b/schema_config/__init__.py
@@ -1,0 +1,9 @@
+"""Schema configuration dataclasses for project management."""
+
+from .models import FieldDefinition, SchemaDefinition, ProjectConfig
+
+__all__ = [
+    "FieldDefinition",
+    "SchemaDefinition",
+    "ProjectConfig",
+]

--- a/schema_config/models.py
+++ b/schema_config/models.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+"""Dataclasses describing schemas and project configuration."""
+
+from dataclasses import dataclass, field, asdict
+from typing import Any, Dict, List, Optional
+import json
+
+try:  # pragma: no cover - optional dependency
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - fallback when PyYAML isn't available
+    yaml = None
+
+
+@dataclass
+class FieldDefinition:
+    """Definition of a single field within a schema."""
+
+    name: str
+    data_type: str
+    required: bool = True
+    description: Optional[str] = None
+    validation: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "FieldDefinition":
+        return cls(**data)
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), indent=2)
+
+    @classmethod
+    def from_json(cls, data: str) -> "FieldDefinition":
+        return cls.from_dict(json.loads(data))
+
+    def to_yaml(self) -> str:
+        if yaml:
+            return yaml.safe_dump(self.to_dict(), sort_keys=False)
+        return json.dumps(self.to_dict(), indent=2)
+
+    @classmethod
+    def from_yaml(cls, data: str) -> "FieldDefinition":
+        if yaml:
+            raw = yaml.safe_load(data)
+        else:
+            raw = json.loads(data)
+        return cls.from_dict(raw)
+
+
+@dataclass
+class SchemaDefinition:
+    """Collection of fields describing a dataset schema."""
+
+    name: str
+    file_path: Optional[str] = None
+    fields: List[FieldDefinition] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        data["fields"] = [f.to_dict() for f in self.fields]
+        return data
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SchemaDefinition":
+        fields = [FieldDefinition.from_dict(f) for f in data.get("fields", [])]
+        return cls(
+            name=data["name"],
+            file_path=data.get("file_path"),
+            fields=fields,
+            metadata=data.get("metadata", {}),
+        )
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), indent=2)
+
+    @classmethod
+    def from_json(cls, data: str) -> "SchemaDefinition":
+        return cls.from_dict(json.loads(data))
+
+    def to_yaml(self) -> str:
+        if yaml:
+            return yaml.safe_dump(self.to_dict(), sort_keys=False)
+        return json.dumps(self.to_dict(), indent=2)
+
+    @classmethod
+    def from_yaml(cls, data: str) -> "SchemaDefinition":
+        if yaml:
+            raw = yaml.safe_load(data)
+        else:
+            raw = json.loads(data)
+        return cls.from_dict(raw)
+
+
+@dataclass
+class ProjectConfig:
+    """Configuration for a project with source and target schemas."""
+
+    name: str
+    target: SchemaDefinition
+    sources: List[SchemaDefinition] = field(default_factory=list)
+    description: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "description": self.description,
+            "target": self.target.to_dict(),
+            "sources": [s.to_dict() for s in self.sources],
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ProjectConfig":
+        target = SchemaDefinition.from_dict(data["target"])
+        sources = [SchemaDefinition.from_dict(s) for s in data.get("sources", [])]
+        return cls(
+            name=data["name"],
+            target=target,
+            sources=sources,
+            description=data.get("description"),
+        )
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), indent=2)
+
+    @classmethod
+    def from_json(cls, data: str) -> "ProjectConfig":
+        return cls.from_dict(json.loads(data))
+
+    def to_yaml(self) -> str:
+        if yaml:
+            return yaml.safe_dump(self.to_dict(), sort_keys=False)
+        return json.dumps(self.to_dict(), indent=2)
+
+    @classmethod
+    def from_yaml(cls, data: str) -> "ProjectConfig":
+        if yaml:
+            raw = yaml.safe_load(data)
+        else:
+            raw = json.loads(data)
+        return cls.from_dict(raw)

--- a/tests/test_project_config.py
+++ b/tests/test_project_config.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from schema_config import FieldDefinition, SchemaDefinition, ProjectConfig
+
+
+def sample_config() -> ProjectConfig:
+    id_field = FieldDefinition(name="id", data_type="integer", validation={"min": 0})
+    name_field = FieldDefinition(name="name", data_type="string", required=False)
+
+    source1 = SchemaDefinition(name="source1", file_path="source1.csv", fields=[id_field, name_field])
+    source2 = SchemaDefinition(name="source2", file_path="source2.csv", fields=[id_field])
+    target = SchemaDefinition(name="target", file_path="target.csv", fields=[id_field, name_field])
+
+    return ProjectConfig(name="project", target=target, sources=[source1, source2])
+
+
+def test_json_serialization_roundtrip():
+    config = sample_config()
+
+    dumped = config.to_json()
+    loaded = ProjectConfig.from_json(dumped)
+
+    assert loaded == config
+
+
+def test_yaml_serialization_roundtrip():
+    config = sample_config()
+
+    dumped = config.to_yaml()
+    loaded = ProjectConfig.from_yaml(dumped)
+
+    assert loaded == config


### PR DESCRIPTION
## Summary
- introduce FieldDefinition, SchemaDefinition, and ProjectConfig dataclasses
- support JSON/YAML (with optional PyYAML) serialization and deserialization
- add tests covering round-trip serialization for multiple source schemas and one target

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c564309bdc8330a752d67eca5a9d8b