### PR TITLE
Add workbook validation to upload workflow

### DIFF
--- a/tests/test_workbook_validator.py
+++ b/tests/test_workbook_validator.py
@@ -1,0 +1,49 @@
+import pytest
+
+openpyxl = pytest.importorskip("openpyxl", reason="openpyxl is required to run workbook tests")
+from openpyxl import Workbook
+
+from workbook_validator import WorkbookValidationError, validate_workbook
+
+
+def _create_workbook(schema_headers=None, data_header=None):
+    wb = Workbook()
+    schema_ws = wb.active
+    schema_ws.title = "Schema"
+    if schema_headers is None:
+        schema_headers = ["field_name", "data_type", "nullable"]
+    schema_ws.append(schema_headers)
+    schema_ws.append(["id", "integer", False])
+
+    data_ws = wb.create_sheet("Data")
+    if data_header is None:
+        data_header = ["id"]
+    data_ws.append(data_header)
+    return wb
+
+
+def test_valid_workbook(tmp_path):
+    wb = _create_workbook()
+    path = tmp_path / "valid.xlsx"
+    wb.save(path)
+    validate_workbook(path)
+
+
+def test_missing_required_sheet(tmp_path):
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Schema"
+    ws.append(["field_name", "data_type", "nullable"])
+    ws.append(["id", "integer", False])
+    path = tmp_path / "missing_data.xlsx"
+    wb.save(path)
+    with pytest.raises(WorkbookValidationError):
+        validate_workbook(path)
+
+
+def test_mismatched_data_headers(tmp_path):
+    wb = _create_workbook(data_header=["wrong"])
+    path = tmp_path / "mismatch.xlsx"
+    wb.save(path)
+    with pytest.raises(WorkbookValidationError):
+        validate_workbook(path)

--- a/upload_workflow.py
+++ b/upload_workflow.py
@@ -1,0 +1,24 @@
+"""Simple upload workflow integrating workbook validation."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+from workbook_validator import WorkbookValidationError, validate_workbook
+
+
+def upload_workbook(path: str | Path) -> Dict[str, Any]:
+    """Process an uploaded workbook located at *path*.
+
+    Returns a dictionary describing the outcome. Invalid workbooks are rejected
+    with a descriptive error message, while valid workbooks return a success
+    status. In a real application this is where the workbook would be persisted
+    or further processed.
+    """
+    try:
+        validate_workbook(str(path))
+    except WorkbookValidationError as exc:
+        return {"status": "error", "error": str(exc)}
+
+    # Placeholder for additional processing of the workbook.
+    return {"status": "ok"}

--- a/workbook_validator.py
+++ b/workbook_validator.py
@@ -1,0 +1,69 @@
+"""Workbook validation utilities."""
+from __future__ import annotations
+
+from typing import List
+
+from openpyxl import load_workbook
+
+
+REQUIRED_SHEETS = ["Schema", "Data"]
+REQUIRED_SCHEMA_COLUMNS = ["field_name", "data_type", "nullable"]
+
+
+class WorkbookValidationError(Exception):
+    """Raised when a workbook fails validation."""
+
+
+def _get_header(row) -> List[str]:
+    """Return trimmed string values from a row of cells."""
+    values: List[str] = []
+    for cell in row:
+        value = cell.value
+        if isinstance(value, str):
+            value = value.strip()
+        values.append(value)
+    return values
+
+
+def validate_workbook(path: str) -> None:
+    """Validate that the workbook at *path* meets requirements.
+
+    The function raises :class:`WorkbookValidationError` with a descriptive
+    message when validation fails. Successful validation returns ``None``.
+    """
+    try:
+        wb = load_workbook(filename=path, read_only=True, data_only=True)
+    except Exception as exc:  # pragma: no cover - exceptional path
+        raise WorkbookValidationError(f"Unable to open workbook: {exc}") from exc
+
+    try:
+        missing = [s for s in REQUIRED_SHEETS if s not in wb.sheetnames]
+        if missing:
+            raise WorkbookValidationError(
+                f"Workbook missing required sheet(s): {', '.join(missing)}"
+            )
+
+        schema_ws = wb["Schema"]
+        header = _get_header(next(schema_ws.iter_rows(min_row=1, max_row=1)))
+        missing_cols = [c for c in REQUIRED_SCHEMA_COLUMNS if c not in header]
+        if missing_cols:
+            raise WorkbookValidationError(
+                "Schema sheet missing required column(s): "
+                + ", ".join(missing_cols)
+            )
+
+        # Obtain declared field names from schema
+        field_names = [
+            row[0].value
+            for row in schema_ws.iter_rows(min_row=2, max_col=1)
+            if row[0].value is not None
+        ]
+
+        data_ws = wb["Data"]
+        data_header = _get_header(next(data_ws.iter_rows(min_row=1, max_row=1)))
+        if data_header != field_names:
+            raise WorkbookValidationError(
+                "Data sheet headers do not match field names defined in Schema"
+            )
+    finally:
+        wb.close()


### PR DESCRIPTION
## Summary
- add validator ensuring required sheets and columns exist
- wire validation into upload workflow with descriptive errors
- add tests for validating workbooks

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c564352da483309267be31a09b06f3