### PR TITLE
Add schema validation and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/schema_validator/__init__.py
+++ b/schema_validator/__init__.py
@@ -1,0 +1,4 @@
+"""Schema validation utilities."""
+from .validator import validate_schema_data
+
+__all__ = ["validate_schema_data"]

--- a/schema_validator/validator.py
+++ b/schema_validator/validator.py
@@ -1,0 +1,117 @@
+"""Validation logic for schemas and sample data."""
+from __future__ import annotations
+from typing import Any, Dict, List, Tuple, Optional, Set
+
+
+class ValidationError(Exception):
+    """Raised when critical mismatches are found during validation."""
+
+
+def _is_null(value: Any) -> bool:
+    """Return True if value should be considered null."""
+    return value is None or (isinstance(value, str) and value == "")
+
+
+def _check_type(value: Any, expected_type: str) -> bool:
+    """Validate a single value against an expected type."""
+    if _is_null(value):
+        return True  # Nullability handled separately
+
+    expected_type = expected_type.lower()
+    try:
+        if expected_type.startswith("int"):
+            int(value)
+        elif expected_type.startswith("float"):
+            float(value)
+        elif expected_type in {"string", "str"}:
+            str(value)
+        else:
+            return False
+    except (ValueError, TypeError):
+        return False
+    return True
+
+
+def validate_schema_data(
+    schema: List[Dict[str, Any]],
+    data: List[Dict[str, Any]],
+    fk_reference: Optional[Dict[str, Set[Any]]] = None,
+) -> Tuple[bool, Dict[str, List[str]]]:
+    """Validate sample data against a schema.
+
+    Parameters
+    ----------
+    schema:
+        List of field definitions. Each definition should contain at least
+        ``field_name`` and ``data_type``. Optional keys include ``length``,
+        ``nullable`` (bool), ``primary_key`` (bool) and ``foreign_key_ref``.
+    data:
+        Sample data represented as a list of dictionaries mapping field names to
+        values.
+    fk_reference:
+        Optional mapping of field name to a set of allowed values for foreign
+        key validation.
+
+    Returns
+    -------
+    Tuple of ``(is_valid, errors)`` where ``is_valid`` indicates whether the
+    sample data satisfies all constraints and ``errors`` maps field names to a
+    list of human readable violation messages.
+
+    Any violation results in ``is_valid`` being ``False``. Callers should block
+    project save when ``is_valid`` is ``False``.
+    """
+
+    fk_reference = fk_reference or {}
+    errors: Dict[str, List[str]] = {}
+
+    # Precompute data column lists for efficiency
+    column_values: Dict[str, List[Any]] = {name: [] for name in [f["field_name"] for f in schema]}
+    for row in data:
+        for name in column_values:
+            column_values[name].append(row.get(name))
+
+    for field in schema:
+        name = field["field_name"]
+        expected_type = field.get("data_type", "string")
+        length = field.get("length")
+        nullable = field.get("nullable", True)
+        is_primary = bool(field.get("primary_key"))
+        fk_ref = field.get("foreign_key_ref")
+        field_errors: List[str] = []
+
+        values = column_values[name]
+
+        # Validate individual values
+        for i, value in enumerate(values):
+            if not _check_type(value, expected_type):
+                field_errors.append(f"Row {i}: value {value!r} does not match type {expected_type}")
+            if not nullable and _is_null(value):
+                field_errors.append(f"Row {i}: null value in non-nullable field")
+            if isinstance(value, str) and length and len(value) > int(length):
+                field_errors.append(
+                    f"Row {i}: value {value!r} exceeds max length {length}"
+                )
+
+        # Primary key constraint: uniqueness and non-null
+        if is_primary:
+            non_null_values = [v for v in values if not _is_null(v)]
+            if len(non_null_values) != len(set(non_null_values)):
+                field_errors.append("Duplicate values in primary key column")
+            if any(_is_null(v) for v in values):
+                field_errors.append("Null value in primary key column")
+
+        # Foreign key constraint
+        if fk_ref:
+            allowed = fk_reference.get(name, set())
+            for i, value in enumerate(values):
+                if not _is_null(value) and value not in allowed:
+                    field_errors.append(
+                        f"Row {i}: value {value!r} not present in foreign key reference"
+                    )
+
+        if field_errors:
+            errors[name] = field_errors
+
+    is_valid = not errors
+    return is_valid, errors

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,0 +1,72 @@
+import os
+import sys
+
+import pytest
+
+# Ensure the package root is on the Python path when running tests directly
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from schema_validator import validate_schema_data
+
+
+def test_valid_data():
+    schema = [
+        {"field_name": "id", "data_type": "int64", "primary_key": True, "nullable": False},
+        {"field_name": "name", "data_type": "string", "length": 10, "nullable": False},
+        {"field_name": "ref_id", "data_type": "int64", "foreign_key_ref": "ref_table"},
+    ]
+    data = [
+        {"id": 1, "name": "Alice", "ref_id": 1},
+        {"id": 2, "name": "Bob", "ref_id": 2},
+    ]
+    fk_reference = {"ref_id": {1, 2}}
+
+    is_valid, errors = validate_schema_data(schema, data, fk_reference)
+    assert is_valid
+    assert errors == {}
+
+
+def test_violations():
+    schema = [
+        {"field_name": "id", "data_type": "int64", "primary_key": True, "nullable": False},
+        {"field_name": "name", "data_type": "string", "length": 5, "nullable": False},
+        {"field_name": "ref_id", "data_type": "int64", "foreign_key_ref": "ref_table"},
+    ]
+    data = [
+        {"id": 1, "name": "Alice", "ref_id": 3},  # invalid FK
+        {"id": 1, "name": "", "ref_id": 1},       # duplicate PK and null name
+    ]
+    fk_reference = {"ref_id": {1, 2}}
+
+    is_valid, errors = validate_schema_data(schema, data, fk_reference)
+    assert not is_valid
+    # Ensure all expected keys have violations
+    assert set(errors.keys()) == {"id", "name", "ref_id"}
+    assert any("Duplicate" in msg for msg in errors["id"])
+    assert any("null value" in msg for msg in errors["name"])
+    assert any("foreign key" in msg for msg in errors["ref_id"])
+
+
+def test_source_and_target_use_same_logic():
+    source_schema = [
+        {"field_name": "id", "data_type": "int64", "primary_key": True, "nullable": False},
+        {"field_name": "name", "data_type": "string", "length": 10, "nullable": False},
+    ]
+    source_data = [
+        {"id": 1, "name": "Ann"},
+        {"id": 2, "name": "Ben"},
+    ]
+
+    target_schema = [
+        {"field_name": "id", "data_type": "int64", "primary_key": True, "nullable": False},
+        {"field_name": "name", "data_type": "string", "length": 3, "nullable": False},
+    ]
+    target_data = [
+        {"id": 1, "name": "Anna"},  # length exceeds 3
+        {"id": 2, "name": "Ben"},
+    ]
+
+    assert validate_schema_data(source_schema, source_data)[0]
+    is_valid, errors = validate_schema_data(target_schema, target_data)
+    assert not is_valid
+    assert "name" in errors and any("exceeds" in msg for msg in errors["name"])


### PR DESCRIPTION
## Summary
- implement schema validator checking data types, nullability, length, primary and foreign keys
- add tests verifying valid and invalid schemas and ensuring consistent source/target validation
- ignore Python cache files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5643bc50883308a2dc248954122f4