### PR TITLE
Add error handling utility and demo CLI

### DIFF
--- a/demo_cli.py
+++ b/demo_cli.py
@@ -1,0 +1,22 @@
+"""Simple CLI demonstrating error handling."""
+from error_handler import DataError, ErrorCollector
+
+
+def main() -> None:
+    collector = ErrorCollector()
+
+    # Example: an incorrect value type
+    collector.add_error(
+        DataError(
+            field_name="age",
+            row_number=5,
+            message="expected int64 but got string",
+            suggestion="Convert value to integer",
+        )
+    )
+
+    collector.display()
+
+
+if __name__ == "__main__":
+    main()

--- a/error_handler.py
+++ b/error_handler.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+import logging
+
+
+@dataclass
+class DataError:
+    """Represent a validation error for a specific field."""
+    field_name: str
+    row_number: Optional[int]
+    message: str
+    suggestion: Optional[str] = None
+
+    def __str__(self) -> str:
+        base = f"{self.message} (field: {self.field_name}"
+        if self.row_number is not None:
+            base += f", row: {self.row_number}"
+        base += ")"
+        if self.suggestion:
+            base += f" Suggestion: {self.suggestion}"
+        return base
+
+
+class ErrorCollector:
+    """Collects DataError objects and handles logging/display."""
+
+    def __init__(self, log_file: str = "errors.log") -> None:
+        self.errors: List[DataError] = []
+        logging.basicConfig(
+            filename=log_file,
+            level=logging.INFO,
+            format="%(message)s",
+        )
+        self.logger = logging.getLogger("data_error_logger")
+
+    def add_error(self, error: DataError) -> None:
+        """Add an error to the collection and persist it to the log."""
+        self.errors.append(error)
+        self.logger.info(str(error))
+
+    def display(self) -> None:
+        """Display collected errors to the console."""
+        for err in self.errors:
+            print(str(err))


### PR DESCRIPTION
## Summary
- define `DataError` dataclass to capture field name, optional row number, message and suggestions
- add `ErrorCollector` that logs errors to a file and prints them to the console
- provide `demo_cli.py` showing how to record and display an error

## Testing
- `python demo_cli.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c564424128833087b83ce96e1cc8c0