### PR TITLE
Add profiling placeholders and schema identifiers

### DIFF
--- a/project_config.py
+++ b/project_config.py
@@ -1,0 +1,44 @@
+"""Project configuration models for the data profiler.
+
+These data classes define placeholders for profiler output so that
+future components can persist metrics without changing the overall
+configuration structure.
+
+Extension points
+----------------
+``ProjectConfig.field_profiles`` and ``ProjectConfig.table_profiles``
+are intentionally open ended. They are mappings keyed by field or
+table identifier and each profile exposes a ``statistics`` mapping that
+can accept any key/value pair. As additional profiler metrics are
+implemented, they can be stored here without modifying existing code.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Any
+
+
+@dataclass
+class FieldProfile:
+    """Stores profiling statistics for a single field."""
+
+    field_id: str
+    statistics: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class TableProfile:
+    """Stores profiling statistics for a table."""
+
+    table_id: str
+    statistics: Dict[str, Any] = field(default_factory=dict)
+    field_profiles: Dict[str, FieldProfile] = field(default_factory=dict)
+
+
+@dataclass
+class ProjectConfig:
+    """Top-level project configuration including profiler results."""
+
+    project_name: str
+    table_profiles: Dict[str, TableProfile] = field(default_factory=dict)
+    field_profiles: Dict[str, FieldProfile] = field(default_factory=dict)

--- a/readme
+++ b/readme
@@ -43,3 +43,18 @@ Quality_Issues: Fields with data quality problems (for example if the sample dat
 
 
 
+
+## Profiler output extensions
+
+The project configuration models expose placeholders for storing profiler
+results.
+
+* ``schema.py`` defines ``TableSchema`` and ``FieldSchema`` classes that carry
+  stable ``id`` values so profiler metrics can be matched back to the
+  original definitions.
+* ``project_config.py`` provides ``field_profiles`` and ``table_profiles``
+  dictionaries. Each profile maintains a flexible ``statistics`` mapping
+  where new metrics can be added without changing existing code.
+
+Future profilers may introduce additional structures or keys inside these
+mappings as more types of analysis are supported.

--- a/schema.py
+++ b/schema.py
@@ -1,0 +1,29 @@
+"""Schema definition models with identifiers for profiler integration.
+
+Each table and field is assigned a stable ``id`` value so that profiling
+results can be associated back to the original schema definition.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class FieldSchema:
+    """Metadata describing a field within a table."""
+
+    id: str
+    name: str
+    data_type: str = ""
+    description: str = ""
+    nullable: bool = True
+
+
+@dataclass
+class TableSchema:
+    """Collection of fields describing a table."""
+
+    id: str
+    name: str
+    fields: List[FieldSchema] = field(default_factory=list)


### PR DESCRIPTION
## Summary
- define profiling models and placeholder fields in `ProjectConfig`
- give schema definitions table and field identifiers
- document extension points for profiler outputs

## Testing
- `python -m py_compile project_config.py schema.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5644647f48330a9c07acaf018179b